### PR TITLE
Add random audio (both audio and voice), keep inline audio as TODO

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  tests:
 
     runs-on: ubuntu-latest
 
@@ -20,6 +20,9 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Set up system environment
+      run: |
+      	sudo apt-get install -y ffmpeg
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 A telegram bot to generate random stuff, I built this to chat with my friend by randomly
 
 ## Dependency
-pyTelegrambotAPI
+- pyTelegrambotAPI
+- pytest (dev)
+- ffmpeg-python
+``` shell
+python3 -m pip install -r requirements.txt
+```
+
+## Testing
+run pytest
+
+``` shell
+python3 -m pytest
+```
 
 ## Running
 In the project directory

--- a/app/handlers/audio_handler.py
+++ b/app/handlers/audio_handler.py
@@ -1,0 +1,20 @@
+# audio_handler.py
+
+from telebot import TeleBot
+from telebot.types import Message
+
+from app.services.audio_service import generate_random_audio
+from app.services.audio_service import generate_random_voice
+
+# invoke with "/random_audio" command
+def get_random_audio(message: Message, bot: TeleBot):
+    # pretend to be uploading audio
+    bot.send_chat_action(message.chat.id, "upload_voice")
+    audio = generate_random_audio()
+    bot.send_audio(message.chat.id, audio)
+
+def get_random_voice(message: Message, bot: TeleBot):
+    # pretend to be sending voice
+    bot.send_chat_action(message.chat.id, "record_voice")
+    voice = generate_random_voice()
+    bot.send_voice(message.chat.id, voice)

--- a/app/handlers/inline_handler.py
+++ b/app/handlers/inline_handler.py
@@ -3,12 +3,16 @@
 from telebot import TeleBot
 from telebot import types
 
-from app.services.text_service import generate_random_text 
+from app.services.text_service import generate_random_text
+from app.services.audio_service import generate_random_audio
 
 def inline_dispatch(inline_query, bot: TeleBot):
     try:
         text = types.InlineQueryResultArticle('1', 'Random Text',
                                               types.InputTextMessageContent(generate_random_text()))
-        bot.answer_inline_query(inline_query.id, [text], cache_time=0)
+        audio = types.InlineQueryResultArticle('2',
+                                               'TODO',
+                                               types.InputTextMessageContent("TODO"))
+        bot.answer_inline_query(inline_query.id, [text, audio], cache_time=0)
     except Exception as e:
         print(e)

--- a/app/handlers/text_handler.py
+++ b/app/handlers/text_handler.py
@@ -9,10 +9,14 @@ SPECIAL = ['_', '*', '[', ']', '(', ')', '~', '`', '<' , '>', '#', '+', '-', '='
 
 # invoke with "/random" command
 def get_random_text(message: Message, bot: TeleBot):
+    # pretend to be typing
+    bot.send_chat_action(message.chat.id, "typing")
     bot.send_message(message.chat.id, generate_random_text())
 
 # invoke with "/random_mono"
 def get_random_text_mono(message: Message, bot: TeleBot):
+    # pretend to be typing
+    bot.send_chat_action(message.chat.id, "typing")
     text = generate_random_text()
     # add an "\" before every special char for parsing markdown
     for i in SPECIAL:

--- a/app/services/audio_service.py
+++ b/app/services/audio_service.py
@@ -1,0 +1,58 @@
+# audio_service
+
+import wave
+import random
+import struct
+import uuid
+import ffmpeg
+
+from configs import config
+
+# Generate random audio in .wav
+def generate_random_audio():
+    # filename
+    name = uuid.uuid4().hex
+    audio_path = config.AUDIO_DIR+"/"+name+".wav"
+    # open file in write mode
+    audio = wave.open(audio_path, "wb")
+    audio.setparams((2, 2, 44100, 0, 'NONE', 'not compressed'))
+
+    values = []
+
+    # length of the audio (in chunks)
+    len = random.randint(20, 60)
+    # generate the content of the audio
+    for i in range(0, len):
+        v1 = random.randint(-32768, 32768)
+        v2 = random.randint(-32768, 32768)
+        v1_packed = struct.pack('h', v1)
+        v2_packed = struct.pack('h', v2)
+        # chunk duration
+        duration = random.randint(1000, 10000)
+        for j in range(0, duration):
+            values.append(v1_packed)
+            values.append(v2_packed)
+    # make a byte string
+    values_str = b''.join(values)
+    # write into the file
+    audio.writeframes(values_str)
+    # close
+    audio.close()
+    
+    return open(audio_path, "rb")
+
+# generate random voice in .ogg by converting .wav file
+def generate_random_voice():
+    # generate a random wav file
+    wavfile = generate_random_audio()
+    # file name of the generated .ogg
+    oggfile = wavfile.name+".ogg"
+    # convert with ffmpeg
+    (
+        ffmpeg
+        .input(wavfile.name, format="wav")
+        .output(oggfile, acodec = "libopus")
+        .run()
+    )
+
+    return open(oggfile, "rb")

--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,17 @@ from telebot import types
 
 bot = telebot.TeleBot(config.BOT_TOKEN)
 
+def commands():
+    bot.set_my_commands([
+        telebot.types.BotCommand("help", "Get info"),
+        telebot.types.BotCommand("random", "Random text"),
+        telebot.types.BotCommand("random_mono", "Monospace random text"),
+        telebot.types.BotCommand("random_audio", "Random audio"),
+        telebot.types.BotCommand("random_voice", "Random voice")
+    ])
+
+commands()
+
 def handlers():
     # info
     bot.register_message_handler(get_info, commands=['start', 'help'], pass_bot=True)

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,8 @@ from configs import config
 from app.handlers.info_handler import get_info
 from app.handlers.text_handler import get_random_text
 from app.handlers.text_handler import get_random_text_mono
+from app.handlers.audio_handler import get_random_audio
+from app.handlers.audio_handler import get_random_voice
 from app.handlers.inline_handler import inline_dispatch
 
 # pyTelegramBotAPI
@@ -16,9 +18,16 @@ from telebot import types
 bot = telebot.TeleBot(config.BOT_TOKEN)
 
 def handlers():
+    # info
     bot.register_message_handler(get_info, commands=['start', 'help'], pass_bot=True)
+    # random text
     bot.register_message_handler(get_random_text, commands=['random'], pass_bot=True)
     bot.register_message_handler(get_random_text_mono, commands=['random_mono'], pass_bot=True)
+    # random audio
+    bot.register_message_handler(get_random_audio, commands=['random_audio'], pass_bot=True)
+    # random voice
+    bot.register_message_handler(get_random_voice, commands=['random_voice'], pass_bot=True)
+    # inline
     bot.register_inline_handler(inline_dispatch, lambda query: query, pass_bot=True)
     
 handlers()

--- a/configs/config.py
+++ b/configs/config.py
@@ -4,3 +4,6 @@
 import os
 
 BOT_TOKEN = os.environ["BOT_TOKEN"]
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+STORAGE_DIR = os.path.join(ROOT_DIR, "storage")
+AUDIO_DIR = os.path.join(STORAGE_DIR, "audio")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 certifi==2024.2.2
 charset-normalizer==3.3.2
+ffmpeg-python==0.2.0
+future==1.0.0
 idna==3.6
 iniconfig==2.0.0
 packaging==24.0

--- a/storage/audio/.gitignore
+++ b/storage/audio/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/audio_test.py
+++ b/tests/audio_test.py
@@ -1,0 +1,14 @@
+# audio tests
+
+import io
+
+from app.services.audio_service import generate_random_audio
+from app.services.audio_service import generate_random_voice
+
+def test_audio_generated():
+    audio = generate_random_audio()
+    assert isinstance(audio, io.BufferedIOBase)
+
+def test_voice_generated():
+    voice = generate_random_voice()
+    assert isinstance(voice, io.BufferedIOBase)


### PR DESCRIPTION
- [Add random audio (both audio and voice), keep inline audio as TODO](https://github.com/ravachol-yang/randomology/commit/f49562764da7a0796bb70cc9b895ba199e74cfde)
- [add fake actions](https://github.com/ravachol-yang/randomology/commit/4d5a5b550ede7d55ef2fdbcb7d5066afd8926102)
- [add command list](https://github.com/ravachol-yang/randomology/commit/67a6674083d4650698f5b288fb01fa570a505b1a)
- [add ffmpeg for ci environment](https://github.com/ravachol-yang/randomology/commit/c0fd6f4233e6866c101d78a7085920d4c9b45d02)
- [updated readme](https://github.com/ravachol-yang/randomology/commit/d2c63ab6d9b2be3f71b8a42bed60027ee25d8ed1)

### Add random audio (both audio and voice), keep inline audio as TODO
add services and handlers for generating random `.wav` audio with builtin `wave` module, and converting in to `.ogg` files for sending voices with `ffmpeg-python`. Telegram doesn't support inline voice, inline audio will be implemented after migrating from polling to webhook.
### add fake actions
add fake actions to show a **"sending..."** status
### add command list
automaticly set command list
### add ffmpeg for ci environment
install `ffmpeg` for the ubuntu environment in github actions